### PR TITLE
feat: support google cloudsql

### DIFF
--- a/lib/goose/dbconf.go
+++ b/lib/goose/dbconf.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	_ "github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/dialers/postgres"
 	"github.com/kylelemons/go-gypsy/yaml"
 	"github.com/lib/pq"
 )


### PR DESCRIPTION
should work just by registering its driver.

example usage:

myenv:
    driver: cloudsqlpostgres
    open: host=project:region:instance user=username dbname=database password=the-password sslmode=disable
    dialect: postgres
    import: github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/dialers/postgres